### PR TITLE
gradle 8.10.2 changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,20 +68,23 @@ repositories {
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-      jvmTarget = "21"
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
   }
+
   compileKotlin {
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_21.toString()
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
   }
+
   compileTestKotlin {
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_21.toString()
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
   }
+
   getByName("check") {
     dependsOn(":ktlintCheck", "detekt")
   }


### PR DESCRIPTION
There were a couple of breaking changes in gradle 8.10.2 -> I've fixed these on this branch, which will allow Docker to build successfully

(it's on an epic branch because I needed to get circleCi to build an image)