### PR TITLE
gradle 8.10.2 changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-jammy AS builder
+FROM eclipse-temurin:21-jdk-jammy AS builder
 
 
 WORKDIR /app

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,20 +68,23 @@ repositories {
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-      jvmTarget = "21"
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
   }
+
   compileKotlin {
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_21.toString()
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
   }
+
   compileTestKotlin {
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_21.toString()
+    compilerOptions {
+      jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
   }
+
   getByName("check") {
     dependsOn(":ktlintCheck", "detekt")
   }


### PR DESCRIPTION
Another small change for the Builder to use a jdk rather than jre (app still runs under jre)