### PR TITLE
Revert "Update dependency uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter to v5.4.6"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
   implementation(kotlin("stdlib"))
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.6")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.5")
 
   implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.9")
 


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-workload#662