### PR TITLE
clean up pods after cronjob

### DIFF
--- a/helm_deploy/hmpps-workload/templates/dlq-cronjob.yaml
+++ b/helm_deploy/hmpps-workload/templates/dlq-cronjob.yaml
@@ -10,6 +10,7 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 60
       template:
         spec:
           {{- if .Values.serviceAccountName }}


### PR DESCRIPTION
CP pinged me awhile ago, our CronJobs are not cleaning up after themselves, so we get a few pods in PreProd and Prod with very similar names backing up - and this is confusing Prometheus & CP get additional alerts that something is up with Prometheus

I've added a ttlSecondsAfterFinished = 60 ... so these pods should auto-delete after they have run now