### PR TITLE
WFP-3526 Bring all orders through into notify

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/client/dto/ReallocationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/client/dto/ReallocationDetails.kt
@@ -8,4 +8,5 @@ data class ReallocationDetails(
   val previouslyManagedBy: StaffMember,
   val requirements: List<Requirement>,
   val offences: List<OffenceDetails>,
+  val sentences: List<SentenceDetails>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.Requirement
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.RiskOGRS
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.RiskPredictor
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.RiskSummary
+import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.SentenceDetails
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.StaffMember
 import uk.gov.justice.digital.hmpps.hmppsworkload.domain.AllocateCase
 import uk.gov.justice.digital.hmpps.hmppsworkload.domain.CaseType
@@ -273,7 +274,7 @@ class NotificationService(
       "court_name" to allocationDemandDetails.court.name,
       "sentence_date" to sentenceDate,
       "offences" to mapOffences(reallocationDetails.offences),
-      "order" to "${allocationDemandDetails.sentence.description} (${allocationDemandDetails.sentence.length})",
+      "order" to mapOrders(reallocationDetails.sentences),
     )
   }
 
@@ -313,6 +314,9 @@ class NotificationService(
 
   private fun mapOffences(offences: List<OffenceDetails>): List<String> = offences
     .map { offence -> offence.mainCategory }
+
+  private fun mapOrders(orders: List<SentenceDetails>): List<String> = orders
+    .map { order -> order.description + order.length }
 
   private fun mapRequirements(requirements: List<Requirement>): List<String> = requirements
     .map { requirement -> "${requirement.mainCategory}: ${requirement.subCategory ?: requirement.mainCategory} ${requirement.length}".trimEnd() }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/DefaultSaveWorkloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/DefaultSaveWorkloadServiceTest.kt
@@ -104,6 +104,7 @@ class DefaultSaveWorkloadServiceTest {
       val manager = Manager("003", "001", "SPO", name, false)
       val requirements = listOf(Requirement("Cat 1", "Cat 2", "4 days", id, manager, true))
       val offences = listOf(OffenceDetails("one"))
+      var orders = listOf(SentenceDetails("Adult custody", ZonedDateTime.now(), "12"), SentenceDetails("fredom", ZonedDateTime.now(), "forever"))
       val allocationDemandDetails = AllocationDemandDetails(
         crn, name, staffMember, allocatingStaffMember,
         InitialAppointment(date = LocalDate.now()),
@@ -248,6 +249,7 @@ class DefaultSaveWorkloadServiceTest {
       coEvery { sqsSuccessPublisher.updateRequirement(crn, any(), any()) } just Runs
       coEvery { sqsSuccessPublisher.auditAllocation(crn, any(), any(), any()) } just Runs
       coEvery { workforceAllocationsToDeliusApiClient.getOfficerView(PREVIOUS_STAFF_CODE) } returns OfficerView(PREVIOUS_STAFF_CODE, name, "SPO", null, BigInteger.ONE, BigInteger.ONE, BigInteger.ONE)
+      var orders = listOf(SentenceDetails("Adult custody", ZonedDateTime.now(), "12"), SentenceDetails("fredom", ZonedDateTime.now(), "forever"))
 
       val reallocationDetails = ReallocationDetails(
         toText(allocateCase.allocationReason!!),
@@ -257,6 +259,7 @@ class DefaultSaveWorkloadServiceTest {
         StaffMember(PREVIOUS_STAFF_CODE, name, null, "SPO"),
         requirements,
         offences,
+        orders,
       )
 
       coEvery { notificationService.notifyReallocation(allocationDemandDetails, allocateCase, Tier.A1.name, any()) } returns

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.Requirement
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.RiskOGRS
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.RiskPredictor
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.RiskSummary
+import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.SentenceDetails
 import uk.gov.justice.digital.hmpps.hmppsworkload.client.dto.StaffMember
 import uk.gov.justice.digital.hmpps.hmppsworkload.domain.AllocateCase
 import uk.gov.justice.digital.hmpps.hmppsworkload.domain.CaseType
@@ -470,7 +471,7 @@ class NotificationServiceTests {
       "CRN1111", listOf(firstEmail, secondEmail), false, true, "spo notes",
       laoCase = false, allocationReason = null, nextAppointmentDate = null, lastOasysAssessmentDate = null, failureToComply = null,
     )
-    val reallocationDetails = ReallocationDetails("Laziness", "never", "tomorrow", "12", getManager(), ArrayList<Requirement>(), ArrayList<OffenceDetails>())
+    val reallocationDetails = ReallocationDetails("Laziness", "never", "tomorrow", "12", getManager(), ArrayList<Requirement>(), ArrayList<OffenceDetails>(), ArrayList<SentenceDetails>())
     notificationService.notifyReallocation(allocationDetails, allocateCase, Tier.A1.name, reallocationDetails)
 
     val parameters = slot<NotificationEmail>()
@@ -492,7 +493,7 @@ class NotificationServiceTests {
       "CRN1111", listOf(firstEmail, secondEmail), true, true, "spo notes",
       laoCase = false, allocationReason = null, nextAppointmentDate = null, lastOasysAssessmentDate = null, failureToComply = null,
     )
-    val reallocationDetails = ReallocationDetails("Laziness", "never", "tomorrow", "12", getManager(), ArrayList<Requirement>(), ArrayList<OffenceDetails>())
+    val reallocationDetails = ReallocationDetails("Laziness", "never", "tomorrow", "12", getManager(), ArrayList<Requirement>(), ArrayList<OffenceDetails>(), ArrayList<SentenceDetails>())
     notificationService.notifyReallocation(allocationDetails, allocateCase, Tier.A1.name, reallocationDetails)
 
     var parameters = mutableListOf<NotificationEmail>()


### PR DESCRIPTION
With Initial allocations as we only have one event, we will only have one order.
Reallocations can have multiple events so the code has been changed to create a list of orders and use this to send to notify, as had been done with events and requirements