### PR TITLE
Fix for LAO Previous Practitioner email not sending

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
@@ -174,7 +174,7 @@ class NotificationService(
     if (allocateCase.laoCase) {
       templateId = reallocationPreviousTemplateLAOId
       parameters = mapOf(
-        OFFICER_NAME to reallocationDetail.previouslyManagedBy.name.getCombinedName(),
+        PREVIOUS_PRACTITIONER to reallocationDetail.previouslyManagedBy.name.getCombinedName(),
         ALLOCATING_EMAIL to allocationDemandDetails.allocatingStaff.email!!,
         PRACTITIONER_EMAIL to reallocationDetail.previouslyManagedBy.email!!,
       ).plus(getLoggedInUserParameters(allocationDemandDetails.allocatingStaff))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
@@ -485,7 +485,7 @@ class NotificationServiceTests {
   }
 
   @Test
-  fun `must send reallocation email to new officer and email previous officer`() = runBlocking {
+  fun `must send reallocation emails to new officer and email previous officer`() = runBlocking {
     val allocationDetails = getAllocationDetails(allocateCase.crn)
     val firstEmail = "first@justice.gov.uk"
     val secondEmail = "second@justice.gov.uk"
@@ -518,7 +518,7 @@ class NotificationServiceTests {
   }
 
   @Test
-  fun `must send reallocation email to new officer and email previous officer for lao case`() = runBlocking {
+  fun `must send LAO reallocation emails to new officer and email previous officer for lao case`() = runBlocking {
     val allocationDetails = getAllocationDetails(allocateCase.crn)
     val firstEmail = "first@justice.gov.uk"
     val secondEmail = "second@justice.gov.uk"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
@@ -463,7 +463,7 @@ class NotificationServiceTests {
   }
 
   @Test
-  fun `must send reallocation email to new  officer and not allocating officer or previous officer`() = runBlocking {
+  fun `must send reallocation email to new officer and not allocating officer or previous officer`() = runBlocking {
     val allocationDetails = getAllocationDetails(allocateCase.crn)
     val firstEmail = "first@justice.gov.uk"
     val secondEmail = "second@justice.gov.uk"
@@ -485,7 +485,7 @@ class NotificationServiceTests {
   }
 
   @Test
-  fun `must send reallocation email to new  officer and email previous officer`() = runBlocking {
+  fun `must send reallocation email to new officer and email previous officer`() = runBlocking {
     val allocationDetails = getAllocationDetails(allocateCase.crn)
     val firstEmail = "first@justice.gov.uk"
     val secondEmail = "second@justice.gov.uk"
@@ -505,6 +505,42 @@ class NotificationServiceTests {
 
     val emailTo = HashSet<String>(firstNotification.emailTo)
     val emailToPrevious = HashSet<String>(secondNotification.emailTo)
+
+    Assertions.assertEquals(firstNotification.emailTemplate, reallocationTemplateId)
+    Assertions.assertEquals(secondNotification.emailTemplate, reallocationPreviousTemplateId)
+
+    Assertions.assertEquals(emailTo.size, 3)
+    Assertions.assertTrue(emailTo.contains("simulate-delivered@notifications.service.gov.uk"))
+    Assertions.assertFalse(emailTo.contains("simulate-delivered@justice.gov.uk"))
+
+    Assertions.assertEquals(emailToPrevious.size, 1)
+    Assertions.assertTrue(emailToPrevious.contains("reallocatedFrom@notifications.service.gov.uk"))
+  }
+
+  @Test
+  fun `must send reallocation email to new officer and email previous officer for lao case`() = runBlocking {
+    val allocationDetails = getAllocationDetails(allocateCase.crn)
+    val firstEmail = "first@justice.gov.uk"
+    val secondEmail = "second@justice.gov.uk"
+    val allocateCase = ReallocateCase(
+      "CRN1111", listOf(firstEmail, secondEmail), true, true, "spo notes",
+      laoCase = true, allocationReason = null, nextAppointmentDate = null, lastOasysAssessmentDate = null, failureToComply = null,
+    )
+    val reallocationDetails = ReallocationDetails("Laziness", "never", "tomorrow", "12", getManager(), ArrayList<Requirement>(), ArrayList<OffenceDetails>(), ArrayList<SentenceDetails>())
+    notificationService.notifyReallocation(allocationDetails, allocateCase, Tier.A1.name, reallocationDetails)
+
+    var parameters = mutableListOf<NotificationEmail>()
+
+    coVerify(exactly = 2) { sqsSuccessPublisher.sendNotification(capture(parameters)) }
+
+    val firstNotification = parameters[0]
+    val secondNotification = parameters[1]
+
+    val emailTo = HashSet<String>(firstNotification.emailTo)
+    val emailToPrevious = HashSet<String>(secondNotification.emailTo)
+
+    Assertions.assertEquals(firstNotification.emailTemplate, reallocationTemplateLAOId)
+    Assertions.assertEquals(secondNotification.emailTemplate, reallocationPreviousTemplateLAOId)
 
     Assertions.assertEquals(emailTo.size, 3)
     Assertions.assertTrue(emailTo.contains("simulate-delivered@notifications.service.gov.uk"))


### PR DESCRIPTION
Notify Email was not being sent to previous practitioner for LAO cases. This was because the template for the email required the previous_pp field, which was not being sent.
The change now means the parameters being sent match the required parameters for the template.