### PR TITLE
Wfp 3506 notify risk parameters

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
@@ -296,21 +296,23 @@ class NotificationService(
       "ogrsLevel" to ogrsLevel,
       "ogrsPercentage" to ogrsPercentage,
     )
-    return if (latestRiskPredictor?.outputVersion == "2")
-      riskParameters.plus(mapOf(
-        "roshLabel" to "Risk of serious harm",
-        "rsrLabel" to "Combined Serious Reoffending Predictor",
-        "ogrsLabel" to "All Reoffending Predictor",
-        )
+    return if (latestRiskPredictor?.outputVersion == "2") {
+      riskParameters.plus(
+        mapOf(
+          "roshLabel" to "Risk of serious harm",
+          "rsrLabel" to "Combined Serious Reoffending Predictor",
+          "ogrsLabel" to "All Reoffending Predictor",
+        ),
       )
-    else
-      riskParameters.plus(mapOf(
-        "roshLabel" to "ROSH",
-        "rsrLabel" to "RSR",
-        "ogrsLabel" to "OGRS",
-        )
+    } else {
+      riskParameters.plus(
+        mapOf(
+          "roshLabel" to "ROSH",
+          "rsrLabel" to "RSR",
+          "ogrsLabel" to "OGRS",
+        ),
       )
-
+    }
   }
 
   private fun mapInductionAppointment(initialAppointment: InitialAppointment?, caseType: CaseType): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationService.kt
@@ -289,13 +289,28 @@ class NotificationService(
     val rosh = riskSummary?.overallRiskLevel?.capitalize() ?: SCORE_UNAVAILABLE
     val ogrsLevel = latestRiskPredictor?.getOGRSScoreLevel()?.capitalize() ?: SCORE_UNAVAILABLE
     val ogrsPercentage = latestRiskPredictor?.getOGRSPercentageScore()?.toString() ?: NOT_APPLICABLE
-    return mapOf(
+    val riskParameters = mapOf(
       "rosh" to rosh,
       "rsrLevel" to rsrLevel,
       "rsrPercentage" to rsrPercentage,
       "ogrsLevel" to ogrsLevel,
       "ogrsPercentage" to ogrsPercentage,
     )
+    return if (latestRiskPredictor?.outputVersion == "2")
+      riskParameters.plus(mapOf(
+        "roshLabel" to "Risk of serious harm",
+        "rsrLabel" to "Combined Serious Reoffending Predictor",
+        "ogrsLabel" to "All Reoffending Predictor",
+        )
+      )
+    else
+      riskParameters.plus(mapOf(
+        "roshLabel" to "ROSH",
+        "rsrLabel" to "RSR",
+        "ogrsLabel" to "OGRS",
+        )
+      )
+
   }
 
   private fun mapInductionAppointment(initialAppointment: InitialAppointment?, caseType: CaseType): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/NotificationServiceTests.kt
@@ -332,7 +332,7 @@ class NotificationServiceTests {
   }
 
   @Test
-  fun `must add RSR and OGRS details correctly capitalized when they exists with V1 Risk Predictor Response`() = runBlocking {
+  fun `must add Risk details and labels correctly capitalized when they exists with V1 Risk Predictor Response`() = runBlocking {
     val allocationDetails = getAllocationDetails(allocateCase.crn)
     val riskPredictor = RiskPredictorV1(
       LocalDateTime.now(),
@@ -356,16 +356,19 @@ class NotificationServiceTests {
     Assertions.assertEquals(riskPredictor.getRSRPercentageScore().toString(), parameters.captured.emailParameters["rsrPercentage"])
     Assertions.assertEquals("Low", parameters.captured.emailParameters["ogrsLevel"])
     Assertions.assertEquals(riskPredictor.getOGRSPercentageScore().toString(), parameters.captured.emailParameters["ogrsPercentage"])
+    Assertions.assertEquals("ROSH", parameters.captured.emailParameters["roshLabel"])
+    Assertions.assertEquals("RSR", parameters.captured.emailParameters["rsrLabel"])
+    Assertions.assertEquals("OGRS", parameters.captured.emailParameters["ogrsLabel"])
   }
 
   @Test
-  fun `must add RSR and OGRS details correctly capitalized when they exists with V2 Risk Predictor Response`() = runBlocking {
+  fun `must add Risk details and labels correctly capitalized when they exists with V2 Risk Predictor Response`() = runBlocking {
     val allocationDetails = getAllocationDetails(allocateCase.crn)
     val riskPredictor = RiskPredictorV2(
       LocalDateTime.now(),
       null,
       null,
-      "1",
+      "2",
       RiskPredictorOutputV2(
         AllReoffendingPredictor(null, BigDecimal.TEN, "LOW"),
         null,
@@ -384,6 +387,9 @@ class NotificationServiceTests {
     Assertions.assertEquals(riskPredictor.getRSRPercentageScore().toString(), parameters.captured.emailParameters["rsrPercentage"])
     Assertions.assertEquals("Low", parameters.captured.emailParameters["ogrsLevel"])
     Assertions.assertEquals(riskPredictor.getOGRSPercentageScore().toString(), parameters.captured.emailParameters["ogrsPercentage"])
+    Assertions.assertEquals("Risk of serious harm", parameters.captured.emailParameters["roshLabel"])
+    Assertions.assertEquals("Combined Serious Reoffending Predictor", parameters.captured.emailParameters["rsrLabel"])
+    Assertions.assertEquals("All Reoffending Predictor", parameters.captured.emailParameters["ogrsLabel"])
   }
 
   @Test


### PR DESCRIPTION
Adding in parameters for the risk labels in the notify templates, as per [WFP-3506](https://dsdmoj.atlassian.net/browse/WFP-3506)