### PR TITLE
Fix null pointer exception when tier is missing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/client/HmppsTierApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/client/HmppsTierApiClient.kt
@@ -47,7 +47,7 @@ class HmppsTierApiClient(private val webClient: WebClient) {
     }
   }
 
-  suspend fun getTierByCrns(crns: List<String>): Map<String, String> {
+  suspend fun getTierByCrns(crns: List<String>): Map<String, String?> {
     try {
       return withTimeout(TIMEOUT_VALUE) {
         webClient
@@ -57,7 +57,7 @@ class HmppsTierApiClient(private val webClient: WebClient) {
           .awaitExchange { response ->
             when {
               response.statusCode() == HttpStatus.OK -> {
-                response.awaitBody<Map<String, TierDto>>().mapValues { it.value.tierScore }
+                response.awaitBody<Map<String, TierDto?>>().mapValues { it.value?.tierScore }
               }
               response.statusCode().is5xxServerError -> {
                 throw WorkloadFailedDependencyException("Tier service failed with ${response.statusCode()}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/staff/CaseTotalsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/staff/CaseTotalsService.kt
@@ -52,8 +52,8 @@ class CaseTotalsService(
     return totals
   }
 
-  private suspend fun getTiers(crns: List<String>): Map<String, String> {
-    val tiers = mutableMapOf<String, String>()
+  private suspend fun getTiers(crns: List<String>): Map<String, String?> {
+    val tiers = mutableMapOf<String, String?>()
 
     // Tiering API only accepts 20 CRNs at a time, so we have to batch the calls
     for (chunk in crns.chunked(20)) {
@@ -63,7 +63,7 @@ class CaseTotalsService(
     return tiers
   }
 
-  private fun calculateTotals(cases: List<PersonManagerEntity>, tiers: Map<String, String>): TierCaseTotals {
+  private fun calculateTotals(cases: List<PersonManagerEntity>, tiers: Map<String, String?>): TierCaseTotals {
     var a = BigDecimal.ZERO
     var b = BigDecimal.ZERO
     var c = BigDecimal.ZERO

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/client/HmppsTierApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/client/HmppsTierApiClientTest.kt
@@ -82,4 +82,22 @@ class HmppsTierApiClientTest {
     val webClient = WebClient.builder().exchangeFunction(exchangeFunction).build()
     assertThrows(WorkloadFailedDependencyException::class.java) { runBlocking { HmppsTierApiClient(webClient).getTierByCrns(listOf("X123456", "X234567")) } }
   }
+
+  @Test
+  fun `test get tier by crns accepts nulls`() = runBlocking {
+    val exchangeFunction = ExchangeFunction { _ ->
+      Mono.just(
+        ClientResponse.create(HttpStatus.OK)
+          .header("Content-Type", "application/json")
+          .body("{\"X123456\": {\"tierScore\":\"A\"}, \"X234567\": null}")
+          .build(),
+      )
+    }
+
+    val webClient = WebClient.builder().exchangeFunction(exchangeFunction).build()
+    val result = HmppsTierApiClient(webClient).getTierByCrns(listOf("X123456", "X234567"))
+
+    assertTrue(result["X123456"] == "A")
+    assertTrue(result["X234567"] == null)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/staff/CaseTotalsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsworkload/service/staff/CaseTotalsServiceTest.kt
@@ -38,6 +38,7 @@ class CaseTotalsServiceTest {
         buildCase("X111119", STAFF_CODE_2, TEAM_CODE_2),
         buildCase("X111120", STAFF_CODE_2, TEAM_CODE_2),
         buildCase("X111121", STAFF_CODE_2, TEAM_CODE_2),
+        buildCase("X111122", STAFF_CODE_2, TEAM_CODE_2),
       )
 
       coEvery { hmppsTierApiClient.getTierByCrns(any()) } returns mapOf(
@@ -52,13 +53,14 @@ class CaseTotalsServiceTest {
         "X111119" to "MISSING",
         "X111120" to "NOT_SUPERVISED",
         "X111121" to "INVALID_VALUE", // Treated as 'MISSING'
+        "X111121" to null, // Treated as 'MISSING'
       )
 
       val totals = caseTotalsService.getTeamTotalsByTier(listOf(TEAM_CODE_1, TEAM_CODE_2))
 
       assertEquals(2, totals.size)
       assertEquals(TierCaseTotals(BigDecimal.valueOf(2), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0)), totals["$TEAM_CODE_1-$STAFF_CODE_1"])
-      assertEquals(TierCaseTotals(BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(1)), totals["$TEAM_CODE_2-$STAFF_CODE_2"])
+      assertEquals(TierCaseTotals(BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(0), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(3), BigDecimal.valueOf(1)), totals["$TEAM_CODE_2-$STAFF_CODE_2"])
     }
   }
 
@@ -77,6 +79,7 @@ class CaseTotalsServiceTest {
         buildCase("X111119", STAFF_CODE_1, TEAM_CODE_1),
         buildCase("X111120", STAFF_CODE_1, TEAM_CODE_1),
         buildCase("X111121", STAFF_CODE_1, TEAM_CODE_1),
+        buildCase("X111122", STAFF_CODE_1, TEAM_CODE_1),
       )
 
       coEvery { hmppsTierApiClient.getTierByCrns(any()) } returns mapOf(
@@ -91,11 +94,12 @@ class CaseTotalsServiceTest {
         "X111119" to "MISSING",
         "X111120" to "NOT_SUPERVISED",
         "X111121" to "INVALID_VALUE", // Treated as 'MISSING'
+        "X111121" to null, // Treated as 'MISSING'
       )
 
       val totals = caseTotalsService.getPractitionerTotalsByTier(STAFF_CODE_1, TEAM_CODE_1)
 
-      assertEquals(TierCaseTotals(BigDecimal.valueOf(2), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(1)), totals)
+      assertEquals(TierCaseTotals(BigDecimal.valueOf(2), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(1), BigDecimal.valueOf(3), BigDecimal.valueOf(1)), totals)
     }
   }
 


### PR DESCRIPTION
I mistakenly thought that the bulk tiering endpoint would send us `{ "X123456": { "tierScore": null } }` in this scenario, but it actually just gives `{ "X123456": null }`. This was causing some 500 errors on dev (which the new unit test is able to replicate).